### PR TITLE
feat: 직원 웹훅 컨트롤러에서 MMSWebhookRequestDto를 MMSEmployeeResponseDto로 변경 -…

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -4963,19 +4963,19 @@ let EmployeeWebhookController = class EmployeeWebhookController {
     }
     async webhookCreate(body) {
         console.log('created employee', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
     async webhookUpdate(body) {
         console.log('updated employee', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
     async webhookPositionChanged(body) {
         console.log('position changed', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
     async webhookDepartmentChanged(body) {
         console.log('department changed', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
     async webhookDelete(body) {
         console.log('deleted employee', body);
@@ -4996,7 +4996,7 @@ __decorate([
     (0, throttler_decorator_1.Throttle)(5, 60),
     __param(0, (0, common_1.Body)()),
     __metadata("design:type", Function),
-    __metadata("design:paramtypes", [typeof (_b = typeof mms_employee_response_dto_1.MMSWebhookRequestDto !== "undefined" && mms_employee_response_dto_1.MMSWebhookRequestDto) === "function" ? _b : Object]),
+    __metadata("design:paramtypes", [typeof (_b = typeof mms_employee_response_dto_1.MMSEmployeeResponseDto !== "undefined" && mms_employee_response_dto_1.MMSEmployeeResponseDto) === "function" ? _b : Object]),
     __metadata("design:returntype", Promise)
 ], EmployeeWebhookController.prototype, "webhookCreate", null);
 __decorate([
@@ -5006,7 +5006,7 @@ __decorate([
     (0, throttler_decorator_1.Throttle)(5, 60),
     __param(0, (0, common_1.Body)()),
     __metadata("design:type", Function),
-    __metadata("design:paramtypes", [typeof (_c = typeof mms_employee_response_dto_1.MMSWebhookRequestDto !== "undefined" && mms_employee_response_dto_1.MMSWebhookRequestDto) === "function" ? _c : Object]),
+    __metadata("design:paramtypes", [typeof (_c = typeof mms_employee_response_dto_1.MMSEmployeeResponseDto !== "undefined" && mms_employee_response_dto_1.MMSEmployeeResponseDto) === "function" ? _c : Object]),
     __metadata("design:returntype", Promise)
 ], EmployeeWebhookController.prototype, "webhookUpdate", null);
 __decorate([
@@ -5016,7 +5016,7 @@ __decorate([
     (0, throttler_decorator_1.Throttle)(5, 60),
     __param(0, (0, common_1.Body)()),
     __metadata("design:type", Function),
-    __metadata("design:paramtypes", [typeof (_d = typeof mms_employee_response_dto_1.MMSWebhookRequestDto !== "undefined" && mms_employee_response_dto_1.MMSWebhookRequestDto) === "function" ? _d : Object]),
+    __metadata("design:paramtypes", [typeof (_d = typeof mms_employee_response_dto_1.MMSEmployeeResponseDto !== "undefined" && mms_employee_response_dto_1.MMSEmployeeResponseDto) === "function" ? _d : Object]),
     __metadata("design:returntype", Promise)
 ], EmployeeWebhookController.prototype, "webhookPositionChanged", null);
 __decorate([
@@ -5026,7 +5026,7 @@ __decorate([
     (0, throttler_decorator_1.Throttle)(5, 60),
     __param(0, (0, common_1.Body)()),
     __metadata("design:type", Function),
-    __metadata("design:paramtypes", [typeof (_e = typeof mms_employee_response_dto_1.MMSWebhookRequestDto !== "undefined" && mms_employee_response_dto_1.MMSWebhookRequestDto) === "function" ? _e : Object]),
+    __metadata("design:paramtypes", [typeof (_e = typeof mms_employee_response_dto_1.MMSEmployeeResponseDto !== "undefined" && mms_employee_response_dto_1.MMSEmployeeResponseDto) === "function" ? _e : Object]),
     __metadata("design:returntype", Promise)
 ], EmployeeWebhookController.prototype, "webhookDepartmentChanged", null);
 __decorate([
@@ -5036,7 +5036,7 @@ __decorate([
     (0, throttler_decorator_1.Throttle)(5, 60),
     __param(0, (0, common_1.Body)()),
     __metadata("design:type", Function),
-    __metadata("design:paramtypes", [typeof (_f = typeof mms_employee_response_dto_1.MMSWebhookRequestDto !== "undefined" && mms_employee_response_dto_1.MMSWebhookRequestDto) === "function" ? _f : Object]),
+    __metadata("design:paramtypes", [typeof (_f = typeof mms_employee_response_dto_1.MMSEmployeeResponseDto !== "undefined" && mms_employee_response_dto_1.MMSEmployeeResponseDto) === "function" ? _f : Object]),
     __metadata("design:returntype", Promise)
 ], EmployeeWebhookController.prototype, "webhookDelete", null);
 exports.EmployeeWebhookController = EmployeeWebhookController = __decorate([

--- a/src/application/employee/controllers/webhook.controller.ts
+++ b/src/application/employee/controllers/webhook.controller.ts
@@ -3,7 +3,10 @@ import { EmployeeService } from '../employee.service';
 import { ApiBearerAuth, ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 import { Public } from '@libs/decorators/public.decorator';
 import { Throttle } from '@nestjs/throttler/dist/throttler.decorator';
-import { MMSWebhookRequestDto } from '@resource/application/employee/dtos/mms-employee-response.dto';
+import {
+    MMSEmployeeResponseDto,
+    MMSWebhookRequestDto,
+} from '@resource/application/employee/dtos/mms-employee-response.dto';
 
 @ApiTags('5. 직원 ')
 @ApiBearerAuth()
@@ -21,43 +24,43 @@ export class EmployeeWebhookController {
     @ApiExcludeEndpoint()
     @Public()
     @Throttle(5, 60) // 60초 동안 5번만 허용
-    async webhookCreate(@Body() body: MMSWebhookRequestDto) {
+    async webhookCreate(@Body() body: MMSEmployeeResponseDto) {
         console.log('created employee', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
 
     @Post('webhook/update')
     @ApiExcludeEndpoint()
     @Public()
     @Throttle(5, 60) // 60초 동안 5번만 허용
-    async webhookUpdate(@Body() body: MMSWebhookRequestDto) {
+    async webhookUpdate(@Body() body: MMSEmployeeResponseDto) {
         console.log('updated employee', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
 
     @Post('webhook/position_changed')
     @ApiExcludeEndpoint()
     @Public()
     @Throttle(5, 60) // 60초 동안 5번만 허용
-    async webhookPositionChanged(@Body() body: MMSWebhookRequestDto) {
+    async webhookPositionChanged(@Body() body: MMSEmployeeResponseDto) {
         console.log('position changed', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
 
     @Post('webhook/department_changed')
     @ApiExcludeEndpoint()
     @Public()
     @Throttle(5, 60) // 60초 동안 5번만 허용
-    async webhookDepartmentChanged(@Body() body: MMSWebhookRequestDto) {
+    async webhookDepartmentChanged(@Body() body: MMSEmployeeResponseDto) {
         console.log('department changed', body);
-        await this.employeeService.syncEmployees(body.payload.employee_number);
+        await this.employeeService.syncEmployees(body.employee_number);
     }
 
     @Post('webhook/delete')
     @ApiExcludeEndpoint()
     @Public()
     @Throttle(5, 60) // 60초 동안 5번만 허용
-    async webhookDelete(@Body() body: MMSWebhookRequestDto) {
+    async webhookDelete(@Body() body: MMSEmployeeResponseDto) {
         console.log('deleted employee', body);
         // await this.employeeUseCase.syncEmployee(body.payload.employee_number);
     }


### PR DESCRIPTION
… 웹훅 메서드의 요청 본문 타입을 수정하고, employee_number 필드 접근 방식을 일관되게 조정하여 코드 가독성 향상