### PR TITLE
feat: 비동기 알림 전송 로직 개선 - SaveMaintenanceUsecase에서 알림 생성 메서드에 await 키워드…

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -17492,7 +17492,7 @@ let SaveMaintenanceUsecase = class SaveMaintenanceUsecase {
                 relations: ['vehicleInfo', 'vehicleInfo.resource'],
                 withDeleted: true,
             });
-            this.notificationService.createNotification(notification_type_enum_1.NotificationType.RESOURCE_MAINTENANCE_COMPLETED, {
+            await this.notificationService.createNotification(notification_type_enum_1.NotificationType.RESOURCE_MAINTENANCE_COMPLETED, {
                 resourceId: consumable.vehicleInfo.resource.resourceId,
                 resourceType: consumable.vehicleInfo.resource.type,
                 consumableName: consumable.name,

--- a/src/application/resource/vehicle/usecases/maintenance/saveMaintenance.usecase.ts
+++ b/src/application/resource/vehicle/usecases/maintenance/saveMaintenance.usecase.ts
@@ -71,7 +71,7 @@ export class SaveMaintenanceUsecase {
                 relations: ['vehicleInfo', 'vehicleInfo.resource'],
                 withDeleted: true,
             });
-            this.notificationService.createNotification(
+            await this.notificationService.createNotification(
                 NotificationType.RESOURCE_MAINTENANCE_COMPLETED,
                 {
                     resourceId: consumable.vehicleInfo.resource.resourceId,


### PR DESCRIPTION
…를 추가하여 비동기 처리를 명확히 하고, 알림 전송의 안정성을 높임